### PR TITLE
Adds support for append!/empty! for ComboBox

### DIFF
--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -558,7 +558,7 @@ function dropdown(; choices=nothing,
     allstrings || all(x->isa(x, Pair), choices) || throw(ArgumentError("all elements must either be strings or pairs, got $choices"))
     str2int = Dict{String,Int}()
     getactive(w) = (val = GAccessor.active_text(w); val == C_NULL ? nothing : Gtk.bytestring(val))
-    setactive!(w, val) = set_gtk_property!(w, :active, val === nothing ? 0 : str2int[val])
+    setactive!(w, val) = @idle_add set_gtk_property!(w, :active, val === nothing ? 0 : str2int[val] - 1)
     k = -1
     for c in choices
         str = juststring(c)

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -558,7 +558,7 @@ function dropdown(; choices=nothing,
     allstrings || all(x->isa(x, Pair), choices) || throw(ArgumentError("all elements must either be strings or pairs, got $choices"))
     str2int = Dict{String,Int}()
     getactive(w) = (val = GAccessor.active_text(w); val == C_NULL ? nothing : Gtk.bytestring(val))
-    setactive!(w, val) = @idle_add set_gtk_property!(w, :active, val === nothing ? 0 : str2int[val] - 1)
+    setactive!(w, val) = set_gtk_property!(w, :active, val === nothing ? 0 : str2int[val])
     k = -1
     for c in choices
         str = juststring(c)
@@ -580,7 +580,11 @@ function dropdown(; choices=nothing,
     if !allstrings
         choicedict = Dict(choices...)
         map!(mappedsignal, observable) do val
-            choicedict[val]
+            if val !== nothing
+                choicedict[val]
+            else
+                _ -> nothing
+            end
         end
     end
     if own
@@ -602,7 +606,7 @@ function Base.append!(w::Dropdown, choices)
     allstrings = all(x->isa(x, AbstractString), choices)
     allstrings || all(x->isa(x, Pair), choices) || throw(ArgumentError("all elements must either be strings or pairs, got $choices"))
     allstrings && w.mappedsignal[] === nothing || throw(ArgumentError("only pairs may be added to a combobox with pairs, got $choices"))
-    k = length(w.str2int)
+    k = length(w.str2int) - 1
     for c in choices
         str = juststring(c)
         @idle_add push!(w.widget, str)

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -564,7 +564,7 @@ function dropdown(; choices=nothing,
     allstrings || all(x->isa(x, Pair), choices) || throw(ArgumentError("all elements must either be strings or pairs, got $choices"))
     str2int = Dict{String,Int}()
     getactive(w) = (val = GAccessor.active_text(w); val == C_NULL ? nothing : Gtk.bytestring(val))
-    setactive!(w, val) = (i = val !== nothing ? str2int[val] : -1; set_gtk_property!(w, :active, i))
+    setactive!(w, val) = (i = val !== nothing ? str2int[val] : -1; @idle_add set_gtk_property!(w, :active, i))
     k = -1
     for c in choices
         str = juststring(c)

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -564,7 +564,7 @@ function dropdown(; choices=nothing,
     allstrings || all(x->isa(x, Pair), choices) || throw(ArgumentError("all elements must either be strings or pairs, got $choices"))
     str2int = Dict{String,Int}()
     getactive(w) = (val = GAccessor.active_text(w); val == C_NULL ? nothing : Gtk.bytestring(val))
-    setactive!(w, val) = (i = val !== nothing ? str2int[val] : -1; @idle_add set_gtk_property!(w, :active, i))
+    setactive!(w, val) = (i = val !== nothing ? str2int[val] : -1; set_gtk_property!(w, :active, i))
     k = -1
     for c in choices
         str = juststring(c)
@@ -615,7 +615,7 @@ function Base.append!(w::Dropdown, choices)
     k = length(w.str2int) - 1
     for c in choices
         str = juststring(c)
-        @idle_add push!(w.widget, str)
+        push!(w.widget, str)
         w.str2int[str] = (k+=1)
     end
     return w
@@ -623,7 +623,7 @@ end
 
 function Base.empty!(w::Dropdown)
     empty!(w.str2int)
-    @idle_add empty!(w.widget)
+    empty!(w.widget)
     w.mappedsignal[] = nothing
     return w
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,19 +129,15 @@ include("tools.jl")
     dd = dropdown(("Strawberry", "Vanilla", "Chocolate"), value = "Strawberry")
     @test dd[] === "Strawberry"
     dd[] = "Chocolate"
-    sleep(0.5)
     @test get_gtk_property(dd, "active", Int) == 2
     empty!(dd)
-    sleep(0.5)
     @test dd[] === nothing
     @test get_gtk_property(dd, "active", Int) == -1
     @test_throws KeyError dd[] = "Strawberry"
     @test dd[] === nothing
     append!(dd, ("Coffee", "Caramel"))
-    sleep(0.5)
     @test dd[] === nothing
     dd[] = "Caramel"
-    sleep(0.5)
     @test dd[] == "Caramel"
     @test get_gtk_property(dd, "active", Int) == 1
     destroy(dd.widget)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,6 +130,18 @@ include("tools.jl")
     @test dd[] === "Strawberry"
     dd[] = "Chocolate"
     @test get_gtk_property(dd, "active", Int) == 2
+    empty!(dd)
+    sleep(0.5)
+    @test dd[] === nothing
+    @test get_gtk_property(dd, "active", Int) == -1
+    @test_throws KeyError dd[] = "Strawberry"
+    @test dd[] === nothing
+    append!(dd, ("Coffee", "Caramel"))
+    sleep(0.5)
+    @test dd[] === nothing
+    dd[] = "Caramel"
+    @test dd[] == "Caramel"
+    @test get_gtk_property(dd, "active", Int) == 1
     destroy(dd.widget)
 
     r = Ref(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,14 +125,16 @@ include("tools.jl")
 
     ## dropdown
     dd = dropdown(("Strawberry", "Vanilla", "Chocolate"))
-    @test dd[] == "Strawberry"
+    @test dd[] === nothing
+    dd = dropdown(("Strawberry", "Vanilla", "Chocolate"), value = "Strawberry")
+    @test dd[] === "Strawberry"
     dd[] = "Chocolate"
     @test get_gtk_property(dd, "active", Int) == 2
     destroy(dd.widget)
 
     r = Ref(0)
     dd = dropdown(["Five"=>x->x[]=5,
-                   "Seven"=>x->x[]=7])
+                   "Seven"=>x->x[]=7], value = "Five")
     on(dd.mappedsignal) do f
         f(r)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,9 +125,15 @@ include("tools.jl")
 
     ## dropdown
     dd = dropdown(("Strawberry", "Vanilla", "Chocolate"))
-    @test dd[] === nothing
-    dd = dropdown(("Strawberry", "Vanilla", "Chocolate"), value = "Strawberry")
     @test dd[] === "Strawberry"
+    destroy(dd.widget)
+
+    dd = dropdown(())
+    @test dd[] === nothing
+    destroy(dd.widget)
+
+    dd = dropdown(("Strawberry", "Vanilla", "Chocolate"), value = "Vanilla")
+    @test dd[] === "Vanilla"
     dd[] = "Chocolate"
     @test get_gtk_property(dd, "active", Int) == 2
     empty!(dd)
@@ -156,6 +162,12 @@ include("tools.jl")
     @test r[] == 7
     dd[] = "Five"
     @test r[] == 5
+    destroy(dd.widget)
+
+    # if the Observable is just of type String, don't support unselected state (compatibility with 1.0.0)
+    dd = dropdown(("Strawberry", "Vanilla", "Chocolate"), observable = Observable(""))
+    @test dd[] === "Strawberry"
+    @test_throws ArgumentError empty!(dd)
     destroy(dd.widget)
 
     ## spinbutton

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,6 +129,7 @@ include("tools.jl")
     dd = dropdown(("Strawberry", "Vanilla", "Chocolate"), value = "Strawberry")
     @test dd[] === "Strawberry"
     dd[] = "Chocolate"
+    sleep(0.5)
     @test get_gtk_property(dd, "active", Int) == 2
     empty!(dd)
     sleep(0.5)
@@ -140,6 +141,7 @@ include("tools.jl")
     sleep(0.5)
     @test dd[] === nothing
     dd[] = "Caramel"
+    sleep(0.5)
     @test dd[] == "Caramel"
     @test get_gtk_property(dd, "active", Int) == 1
     destroy(dd.widget)


### PR DESCRIPTION
- ComboBox observable is now `Union{Nothing, String}` to support the unset state.
- Methods for `append!` and `empty!` added to allow options to be changed live, making use of `@idle_add` to run the code on the UI thread.
- Rely on Gtk to get active string, rather than maintaining separate dictionary.