### PR TITLE
Support textbox gtksignals with more arguments and requiring a propagation returnval

### DIFF
--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -445,8 +445,9 @@ function textbox(::Type{T};
     end
     set_gtk_property!(widget, "text", value)
 
-    id = signal_connect(widget, gtksignal) do w
+    id = signal_connect(widget, gtksignal) do w, _...
         setindex!(observable, entrygetter(w, observable, range))
+        return false
     end
 
     preserved = []

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,9 +72,11 @@ include("tools.jl")
     ## textbox (aka Entry)
     txt = textbox("Type something")
     num = textbox(5, range=1:10)
+    lost_focus = textbox("Type something"; gtksignal = "focus-out-event")
     win = Window("Textboxes") |> (bx = Box(:h))
     push!(bx, txt)
     push!(bx, num)
+    push!(bx, lost_focus)
     Gtk.showall(win)
     @test get_gtk_property(txt, "text", String) == "Type something"
     txt[] = "ok"
@@ -94,6 +96,12 @@ include("tools.jl")
     @test meld[] == "other directionX4"
     txt[] = "4"
     @test meld[] == "4X4"
+    @test get_gtk_property(lost_focus, "text", String) == "Type something"
+    set_gtk_property!(lost_focus, "text", "Something!")
+    grab_focus(widget(lost_focus))
+    @test lost_focus[] == "Type something"
+    grab_focus(widget(txt))
+    @test lost_focus[] == "Something!"
     destroy(win)
 
     ## textarea (aka TextView)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,10 +97,11 @@ include("tools.jl")
     txt[] = "4"
     @test meld[] == "4X4"
     @test get_gtk_property(lost_focus, "text", String) == "Type something"
-    set_gtk_property!(lost_focus, "text", "Something!")
     grab_focus(widget(lost_focus))
+    set_gtk_property!(lost_focus, "text", "Something!")
     @test lost_focus[] == "Type something"
-    grab_focus(widget(txt))
+    signal_emit(widget(lost_focus), "focus-out-event", Bool, Gtk.GdkEventAny(0, Ptr{Nothing}(), 0))
+    @test get_gtk_property(lost_focus, "text", String) == "Something!"
     @test lost_focus[] == "Something!"
     destroy(win)
 


### PR DESCRIPTION
Adding a vararg to the signal handler allows events that have multiple arguments, e.g. `focus-out-event`, to be used. That event also has to return `false` instead of `nothing` to propagate the event.