### PR TITLE
Improve printing of Canvas

### DIFF
--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -249,6 +249,8 @@ struct Canvas{U}
 end
 Canvas{U}(w::Integer, h::Integer=-1; own::Bool=true) where U = Canvas{U}(Int(w)::Int, Int(h)::Int; own=own)
 
+Base.show(io::IO, canvas::Canvas{U}) where U = print(io, "GtkObservables.Canvas{$U}()")
+
 """
     canvas(U=DeviceUnit, w=-1, h=-1) - c::GtkObservables.Canvas
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,8 @@ include("tools.jl")
         str*str
     end
     @test ldouble[] == "and againand again"
+    # printing
+    @test string(l) == "Gtk.GtkLabelLeaf with Observable{String} with 2 listeners. Value:\n\"and again\""
 
     ## checkbox
     w = Window("Checkbox")
@@ -325,6 +327,7 @@ if Gtk.libgtk_version >= v"3.10"
                     sleep(0.1)
         end
         @test s[] == 8
+        @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8"
         destroy(win)
 
         p = player(1:1000)
@@ -387,6 +390,7 @@ end
     reveal(c, true)
     sleep(1.0)
     @test isa(c, GtkObservables.Canvas{UserUnit})
+    @test string(c) == "GtkObservables.Canvas{UserUnit}()"
     corner_dev = (DeviceUnit(208), DeviceUnit(207))
     can_test_coords = (VERSION < v"1.3" || get(ENV, "CI", nothing) != "true" || !Sys.islinux()) &&
                       can_test_width


### PR DESCRIPTION
The default printing for canvas includes more detail than necessary.
In particular, printing the `preserved` list can in some cases lead
to OverflowErrors if you have two things which mutually preserve
one another. There appears to be no good reason to print this list
when showing the widget.
