### PR TITLE
Fix task-scheduling conflict in Gtk call

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GtkObservables"
 uuid = "8710efd8-4ad6-11eb-33ea-2d5ceb25a41c"
-version = "1.2.3"
+version = "1.2.4"
 
 [deps]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -166,7 +166,7 @@ function Base.setindex!(s::Slider, (range,value)::Tuple{AbstractRange, Any})
     Gtk.G_.lower(adj, first(range))
     Gtk.G_.upper(adj, last(range))
     Gtk.G_.step_increment(adj, step(range))
-    Gtk.G_.value(widget(s), value)
+    Gtk.@sigatom Gtk.G_.value(widget(s), value)
 end
 Base.setindex!(s::Slider, range::AbstractRange) = setindex!(s, (range, s[]))
 


### PR DESCRIPTION
Unfortunately I don't have a code-test reproducing the problem,
but ImageView was able to trigger the same error described in
https://github.com/JuliaGraphics/Gtk.jl/issues/368.
This robustly fixes it.