### PR TITLE
Close timers in `ondestroy`

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -202,3 +202,5 @@ using SnoopPrecompile
         end
     end
 end
+
+sleep(1)   # ensure all timers are closed

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -79,6 +79,11 @@ Create a `destroy` callback for `widget` that terminates updating dependent sign
 """
 function ondestroy(widget::GtkWidget, preserved::AbstractVector)
     signal_connect(widget, "destroy") do widget
+        for item in preserved
+            if isa(item, Timer)
+                close(item)
+            end
+        end
         empty!(preserved)
     end
     nothing


### PR DESCRIPTION
This is a much-reduced version of #45 to see if it's sufficient to fix all issues, other than having windows pop up during precompilation.