### PR TITLE
More explicit finalization

### DIFF
--- a/src/extrawidgets.jl
+++ b/src/extrawidgets.jl
@@ -126,7 +126,16 @@ end
 Base.unsafe_convert(::Type{Ptr{Gtk.GLib.GObject}}, p::PlayerWithTextbox) =
     Base.unsafe_convert(Ptr{Gtk.GLib.GObject}, frame(p))
 
-Gtk.destroy(p::PlayerWithTextbox) = destroy(frame(p))
+function Gtk.destroy(p::PlayerWithTextbox)
+    destroy(p.play_back)
+    destroy(p.step_back)
+    destroy(p.stop)
+    destroy(p.step_forward)
+    destroy(p.play_forward)
+    destroy(p.entry)
+    destroy(p.scale)
+    destroy(frame(p))
+end
 
 
 ################# A time widget ##########################

--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -249,6 +249,8 @@ struct Canvas{U}
 end
 Canvas{U}(w::Integer, h::Integer=-1; own::Bool=true) where U = Canvas{U}(Int(w)::Int, Int(h)::Int; own=own)
 
+Gtk.destroy(c::Canvas) = destroy(c.widget)
+
 Base.show(io::IO, canvas::Canvas{U}) where U = print(io, "GtkObservables.Canvas{$U}()")
 
 """

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -167,6 +167,7 @@ using SnoopPrecompile
                     circle(ctx, x, y, 5)
                     stroke(ctx)
                 end
+                destroy(c)
                 destroy(win)
             end
             win = GtkWindow() |> (c = canvas(UserUnit))
@@ -197,10 +198,13 @@ using SnoopPrecompile
                         eventscroll(c, UP, UserUnit(8), UserUnit(4), CONTROL))
             signal_emit(widget(c), "scroll-event", Bool,
                         eventscroll(c, RIGHT, UserUnit(8), UserUnit(4), 0))
+            destroy(c)
             destroy(win)
         catch
         end
     end
 end
 
-sleep(1)   # ensure all timers are closed
+GC.gc(true)  # allow canvases to finalize
+sleep(1)     # ensure all timers are closed
+GC.gc(true)  # allow canvases to finalize

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -316,22 +316,22 @@ if Gtk.libgtk_version >= v"3.10"
         ## player widget
         s = Observable(1)
         p = player(s, 1:8)
-        # win = Window("Compound", 400, 100) |> (g = Grid())
-        # g[1,1] = p
-        # Gtk.showall(win)
-        # btn_fwd = p.widget.step_forward
-        # @test s[] == 1
-        # btn_fwd[] = nothing
-        # @test s[] == 2
-        # p.widget.play_forward[] = nothing
-        # for i = 1:7
-        #     sleep(0.1)
-        # end
-        # @test s[] == 8
-        # @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
-        #       string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
-        # destroy(p)
-        # destroy(win)
+        win = Window("Compound", 400, 100) |> (g = Grid())
+        g[1,1] = p
+        Gtk.showall(win)
+        btn_fwd = p.widget.step_forward
+        @test s[] == 1
+        btn_fwd[] = nothing
+        @test s[] == 2
+        p.widget.play_forward[] = nothing
+        for i = 1:7
+            sleep(0.1)
+        end
+        @test s[] == 8
+        @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
+              string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
+        destroy(p)
+        destroy(win)
 
         # p = player(1:1000)
         # win = Window("Compound 2", 400, 100)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,36 +310,36 @@ const counter = Ref(0)
     button(; widget=ToolButton("Save as..."))
 end
 
-if Gtk.libgtk_version >= v"3.10" && !Sys.isapple()
+if Gtk.libgtk_version >= v"3.10"
     # To support GtkBuilder, we need this as the minimum libgtk version
     @testset "Compound widgets" begin
         ## player widget
         s = Observable(1)
         p = player(s, 1:8)
-        win = Window("Compound", 400, 100) |> (g = Grid())
-        g[1,1] = p
-        Gtk.showall(win)
-        btn_fwd = p.widget.step_forward
-        @test s[] == 1
-        btn_fwd[] = nothing
-        @test s[] == 2
-        p.widget.play_forward[] = nothing
-        for i = 1:7
-            sleep(0.1)
-        end
-        @test s[] == 8
-        @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
-              string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
-        destroy(p)
-        destroy(win)
+        # win = Window("Compound", 400, 100) |> (g = Grid())
+        # g[1,1] = p
+        # Gtk.showall(win)
+        # btn_fwd = p.widget.step_forward
+        # @test s[] == 1
+        # btn_fwd[] = nothing
+        # @test s[] == 2
+        # p.widget.play_forward[] = nothing
+        # for i = 1:7
+        #     sleep(0.1)
+        # end
+        # @test s[] == 8
+        # @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
+        #       string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
+        # destroy(p)
+        # destroy(win)
 
-        p = player(1:1000)
-        win = Window("Compound 2", 400, 100)
-        push!(win, frame(p))
-        Gtk.showall(win)
-        widget(p).direction[] = 1
-        destroy(p)
-        destroy(win)  # this should not generate a lot of output
+        # p = player(1:1000)
+        # win = Window("Compound 2", 400, 100)
+        # push!(win, frame(p))
+        # Gtk.showall(win)
+        # widget(p).direction[] = 1
+        # destroy(p)
+        # destroy(win)  # this should not generate a lot of output
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,7 +310,7 @@ const counter = Ref(0)
     button(; widget=ToolButton("Save as..."))
 end
 
-if Gtk.libgtk_version >= v"3.10"
+if Gtk.libgtk_version >= v"3.10" && !Sys.isapple()
     # To support GtkBuilder, we need this as the minimum libgtk version
     @testset "Compound widgets" begin
         ## player widget

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,29 +318,26 @@ if Gtk.libgtk_version >= v"3.10"
         p = player(s, 1:8)
         win = Window("Compound", 400, 100) |> (g = Grid())
         g[1,1] = p
-        # Gtk.showall(win)
-        # sleep(1)
-        # btn_fwd = p.widget.step_forward
-        # @test s[] == 1
-        # btn_fwd[] = nothing
-        # @test s[] == 2
-        # p.widget.play_forward[] = nothing
-        # for i = 1:7
-        #     sleep(0.1)
-        # end
-        # @test s[] == 8
-        # @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
-        #       string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
+        btn_fwd = p.widget.step_forward
+        @test s[] == 1
+        btn_fwd[] = nothing
+        @test s[] == 2
+        p.widget.play_forward[] = nothing
+        for i = 1:7
+            sleep(0.1)
+        end
+        @test s[] == 8
+        @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
+              string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
         destroy(p)
         destroy(win)
 
-        # p = player(1:1000)
-        # win = Window("Compound 2", 400, 100)
-        # push!(win, frame(p))
-        # Gtk.showall(win)
-        # widget(p).direction[] = 1
-        # destroy(p)
-        # destroy(win)  # this should not generate a lot of output
+        p = player(1:1000)
+        win = Window("Compound 2", 400, 100)
+        push!(win, frame(p))
+        widget(p).direction[] = 1
+        destroy(p)
+        destroy(win)  # this should not generate a lot of output
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -325,11 +325,12 @@ if Gtk.libgtk_version >= v"3.10"
         @test s[] == 2
         p.widget.play_forward[] = nothing
         for i = 1:7
-                    sleep(0.1)
+            sleep(0.1)
         end
         @test s[] == 8
         @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
               string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
+        destroy(p)
         destroy(win)
 
         p = player(1:1000)
@@ -337,6 +338,7 @@ if Gtk.libgtk_version >= v"3.10"
         push!(win, frame(p))
         Gtk.showall(win)
         widget(p).direction[] = 1
+        destroy(p)
         destroy(win)  # this should not generate a lot of output
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,8 +318,8 @@ if Gtk.libgtk_version >= v"3.10"
         p = player(s, 1:8)
         win = Window("Compound", 400, 100) |> (g = Grid())
         g[1,1] = p
-        Gtk.showall(win)
-        sleep(1)
+        # Gtk.showall(win)
+        # sleep(1)
         # btn_fwd = p.widget.step_forward
         # @test s[] == 1
         # btn_fwd[] = nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -330,7 +330,7 @@ if Gtk.libgtk_version >= v"3.10"
         @test s[] == 8
         @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
               string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
-        destroy(p)
+        # destroy(p)
         destroy(win)
 
         # p = player(1:1000)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -319,18 +319,19 @@ if Gtk.libgtk_version >= v"3.10"
         win = Window("Compound", 400, 100) |> (g = Grid())
         g[1,1] = p
         Gtk.showall(win)
-        btn_fwd = p.widget.step_forward
-        @test s[] == 1
-        btn_fwd[] = nothing
-        @test s[] == 2
-        p.widget.play_forward[] = nothing
-        for i = 1:7
-            sleep(0.1)
-        end
-        @test s[] == 8
-        @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
-              string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
-        # destroy(p)
+        sleep(1)
+        # btn_fwd = p.widget.step_forward
+        # @test s[] == 1
+        # btn_fwd[] = nothing
+        # @test s[] == 2
+        # p.widget.play_forward[] = nothing
+        # for i = 1:7
+        #     sleep(0.1)
+        # end
+        # @test s[] == 8
+        # @test string(p) == "GtkObservables.PlayerWithTextbox with Observable{Int64} with 2 listeners. Value:\n8" ||
+        #       string(p) == "GtkObservables.PlayerWithTextbox with Observable(8)"
+        destroy(p)
         destroy(win)
 
         # p = player(1:1000)


### PR DESCRIPTION
This ensures that all canvases are destroyed prior to end of precompilation.
Also explicitly destroy the `player` widget during tests.