### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 RoundingIntegers = "d5f540fe-1c90-5db3-b776-2e2f362d9394"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Cairo = "1"
@@ -26,7 +26,7 @@ IntervalSets = "0.5, 0.6, 0.7"
 Observables = "0.4, 0.5"
 Reexport = "0.2, 1"
 RoundingIntegers = "0.2, 1"
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 julia = "1.3"
 
 [extras]

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,6 @@
-using SnoopPrecompile
+using PrecompileTools
 
-@precompile_setup begin
+@setup_workload begin
     function eventbutton(c, event_type, btn, x=DeviceUnit(0), y=DeviceUnit(0), state=0)
         xd, yd = GtkObservables.convertunits(DeviceUnit, c, x, y)
         Gtk.GdkEventButton(event_type,
@@ -48,7 +48,7 @@ using SnoopPrecompile
         error(btn, " not recognized")
 
     imgrand = rand(RGB{N0f8}, 100, 100)
-    @precompile_all_calls begin
+    @compile_workload begin
         # slider
         sl = slider(1:3)
         sl[] = (1:5, 3)


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.
