### PR TITLE
fixes for ImageView port to Gtk4

### DIFF
--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -554,6 +554,12 @@ function init_pan_scroll(canvas::Canvas{U},
     enabled = Observable(true)
     pan = on(canvas.mouse.scroll; weak=true) do event::MouseScroll{U}
         if enabled[]
+            if event.modifiers & CONTROL == CONTROL
+            # filter out zoom events
+            # TODO: figure out how to handle custom filters -- this will fail if the user
+            # sets a modifier other than CONTROL to do zoom
+                return nothing
+            end
             s = 0.1*scrollpm(event.direction)
             if filter_x(event)
                 setindex!(zr, pan_x(zr[], s))

--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -259,9 +259,9 @@ struct MouseHandler{U<:CairoUnit}
         function mousescroll_cb(ec::GtkEventControllerScroll, dx::Float64, dy::Float64)
             vert = (abs(dy)>abs(dx))
             dir = if vert
-                dy > 0 ? Gtk4.ScrollDirection_UP : Gtk4.ScrollDirection_DOWN
+                dy > 0 ? Gtk4.ScrollDirection_DOWN : Gtk4.ScrollDirection_UP
             else
-                dx > 0 ? Gtk4.ScrollDirection_RIGHT : Gtk4.ScrollDirection_LEFT
+                dx > 0 ? Gtk4.ScrollDirection_LEFT : Gtk4.ScrollDirection_RIGHT
             end
             handler.scroll[] = MouseScroll{U}(ec, dir, modifier_ref)
             Cint(1)

--- a/src/player.ui
+++ b/src/player.ui
@@ -4,8 +4,8 @@
   <!-- interface-name player.ui -->
   <requires lib="gtk" version="4.0"/>
       <object class="GtkFrame" id="player_frame1">
-        <property name="hexpand">True</property>
-        <property name="vexpand">True</property>
+        <property name="hexpand">False</property>
+        <property name="vexpand">False</property>
         <child>
           <object class="GtkBox" id="splitv1">
             <property name="orientation">vertical</property>
@@ -39,6 +39,7 @@
                 <child>
                   <object class="GtkEntry" id="index_entry1">
                     <property name="halign">center</property>
+                    <property name="width-chars">5</property>
                   </object>
                 </child>
                 <child>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -655,17 +655,17 @@ end
     ecs = Gtk4.find_controller(widget(c), GtkEventControllerScroll)
     signal_emit(ecs, "scroll", Bool, 0.0, -1.0)
     @test zr[].currentview.x == 4..14
-    @test zr[].currentview.y == 1..7
+    @test zr[].currentview.y == 2..8
     
     # Pan-scroll
     modifier[] = Gtk4.ModifierType_NONE
     signal_emit(ecs, "scroll", Bool, -1.0, 0.0)
     @test zr[].currentview.x == 5..15
-    @test zr[].currentview.y == 1..7
+    @test zr[].currentview.y == 2..8
     
     signal_emit(ecs, "scroll", Bool, 0.0, 1.0)
     @test zr[].currentview.x == 5..15
-    @test zr[].currentview.y == 2..8
+    @test zr[].currentview.y == 3..9
     
     destroy(win)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -653,17 +653,17 @@ end
     signal_emit(ecm, "motion", Nothing, xd.val, yd.val)
     modifier[]=CONTROL
     ecs = Gtk4.find_controller(widget(c), GtkEventControllerScroll)
-    signal_emit(ecs, "scroll", Bool, 0.0, 1.0)
+    signal_emit(ecs, "scroll", Bool, 0.0, -1.0)
     @test zr[].currentview.x == 4..14
     @test zr[].currentview.y == 1..7
     
     # Pan-scroll
     modifier[] = Gtk4.ModifierType_NONE
-    signal_emit(ecs, "scroll", Bool, 1.0, 0.0)
+    signal_emit(ecs, "scroll", Bool, -1.0, 0.0)
     @test zr[].currentview.x == 5..15
     @test zr[].currentview.y == 1..7
     
-    signal_emit(ecs, "scroll", Bool, 0.0, -1.0)
+    signal_emit(ecs, "scroll", Bool, 0.0, 1.0)
     @test zr[].currentview.x == 5..15
     @test zr[].currentview.y == 2..8
     


### PR DESCRIPTION
This PR fixes issues I've discovered while polishing the port of ImageView to Gtk4.

First, the mouse scrolling direction was inadvertently reversed when I ported GtkObservables to Gtk4. I'm not sure if this is a change in the convention of GTK4 vs. GTK3 or a mistake I made. In any case this PR restores the original direction.

Second, this tweaks the GtkBuilder XML for the player widget.

Third, I added a filter to remove zoom events (actually, those with a CONTROL modifier, which is the default for zoom) to avoid panning while zooming.