### PR TITLE
flip direction of horizontal scrolling

### DIFF
--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -275,7 +275,7 @@ function mousescroll_cb(ecp::Ptr, dx::Float64, dy::Float64, handler::MouseHandle
     dir = if vert
         dy > 0 ? Gtk4.ScrollDirection_DOWN : Gtk4.ScrollDirection_UP
     else
-        dx > 0 ? Gtk4.ScrollDirection_LEFT : Gtk4.ScrollDirection_RIGHT
+        dx > 0 ? Gtk4.ScrollDirection_RIGHT : Gtk4.ScrollDirection_LEFT
     end
     modifiers = if handler.modifier_ref === nothing
         Gtk4.current_event_state(ec)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -660,11 +660,11 @@ end
     # Pan-scroll
     modifier[] = Gtk4.ModifierType_NONE
     signal_emit(ecs, "scroll", Bool, -1.0, 0.0)
-    @test zr[].currentview.x == 5..15
+    @test zr[].currentview.x == 3..13
     @test zr[].currentview.y == 2..8
     
     signal_emit(ecs, "scroll", Bool, 0.0, 1.0)
-    @test zr[].currentview.x == 5..15
+    @test zr[].currentview.x == 3..13
     @test zr[].currentview.y == 3..9
     
     destroy(win)


### PR DESCRIPTION
While using Canvas with a trackpad I noticed that the horizontal direction (which was only recently enabled in #56 ) doesn't match the vertical direction. This makes both directions scroll in the "natural" way, where the image moves in the same direction as your fingers.