### PR TITLE
expand bounding box to fix coordinate transformation for highly zoomed image

### DIFF
--- a/src/GtkObservables.jl
+++ b/src/GtkObservables.jl
@@ -127,11 +127,11 @@ function Graphics.set_coordinates(c::Union{GraphicsContext,Canvas,GtkCanvas}, zr
 end
 function Graphics.set_coordinates(c::Union{Canvas,GtkCanvas}, inds::Tuple{AbstractUnitRange,AbstractUnitRange})
     y, x = inds
-    bb = BoundingBox(first(x), last(x), first(y), last(y))
+    bb = BoundingBox(first(x)-0.5, last(x)+0.5, first(y)-0.5, last(y)+0.5)
     set_coordinates(c, bb)
 end
 function Graphics.BoundingBox(xy::XY)
-    BoundingBox(minimum(xy.x), maximum(xy.x), minimum(xy.y), maximum(xy.y))
+    BoundingBox(minimum(xy.x)-0.5, maximum(xy.x)+0.5, minimum(xy.y)-0.5, maximum(xy.y)+0.5)
 end
 
 function Base.setindex!(zr::Observable{ZoomRegion{T}}, cv::XY{ClosedInterval{S}}) where {T,S}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -344,7 +344,7 @@ end
     @test isa(MouseScroll{UserUnit}(), MouseScroll{UserUnit})
     @test isa(MouseScroll{DeviceUnit}(), MouseScroll{DeviceUnit})
 
-    @test BoundingBox(XY(2..4, -15..15)) === BoundingBox(2, 4, -15, 15)
+    @test BoundingBox(XY(2..4, -15..15)) === BoundingBox(1.5, 4.5, -15.5, 15.5)
 
     c = canvas(208, 207)
     win = GtkWindow(c)
@@ -364,8 +364,8 @@ end
     corner_dev = (DeviceUnit(208), DeviceUnit(207))
     can_test_coords = (get(ENV, "CI", nothing) != "true" || !Sys.islinux()) && can_test_width
     for (coords, corner_usr) in ((BoundingBox(0, 1, 0, 1), (UserUnit(1), UserUnit(1))),
-                                 (ZoomRegion((5:10, 3:5)), (UserUnit(5), UserUnit(10))),
-                                 ((-1:1, 101:110), (UserUnit(110), UserUnit(1))))
+                                 (ZoomRegion((5:10, 3:5)), (UserUnit(5.5), UserUnit(10.5))),
+                                 ((-1:1, 101:110), (UserUnit(110.5), UserUnit(1.5))))
         set_coordinates(c, coords)
         if can_test_coords
             @test GtkObservables.convertunits(DeviceUnit, c, corner_dev...) == corner_dev


### PR DESCRIPTION
In ImageView, when very zoomed in, the coordinate label in the bottom left corner sometimes does not exactly match the pixel the cursor is over, particularly near the edges of the zoomed image. I tracked the issue down to the fact that the bounding box for the user units is narrower by 1 than the number of pixels in the zoomed image.