### PR TITLE
allow Gtk 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GtkObservables"
 uuid = "8710efd8-4ad6-11eb-33ea-2d5ceb25a41c"
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
@@ -22,7 +22,7 @@ Colors = "0.12"
 Dates = "1.6"
 FixedPointNumbers = "0.8"
 Graphics = "1"
-Gtk4 = "0.6"
+Gtk4 = "0.6, 0.7"
 IntervalSets = "0.5, 0.6, 0.7"
 LinearAlgebra = "1.6"
 Observables = "0.4, 0.5"

--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -139,8 +139,6 @@ function MouseButton(pos::XY{U}, button::Integer, clicktype, modifiers, n_press=
     MouseButton{U}(pos, UInt32(button), clicktype, modifiers, n_press)
 end
 
-_get_button(modifiers, e::GtkGestureSingle) = Gtk4.current_button(e)
-
 function _get_button(modifiers, e::GtkEventController)
     if modifiers & Gtk4.ModifierType_BUTTON1_MASK == Gtk4.ModifierType_BUTTON1_MASK
         return 1
@@ -149,7 +147,7 @@ function _get_button(modifiers, e::GtkEventController)
     elseif modifiers & Gtk4.ModifierType_BUTTON3_MASK == Gtk4.ModifierType_BUTTON3_MASK
         return 3        
     else
-        return 0
+        return isa(e, GtkGestureSingle) ? Gtk4.current_button(e) : 0
     end
 end
 

--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -139,6 +139,8 @@ function MouseButton(pos::XY{U}, button::Integer, clicktype, modifiers, n_press=
     MouseButton{U}(pos, UInt32(button), clicktype, modifiers, n_press)
 end
 
+_get_button(modifiers, e::GtkGestureSingle) = Gtk4.current_button(e)
+
 function _get_button(modifiers, e::GtkEventController)
     if modifiers & Gtk4.ModifierType_BUTTON1_MASK == Gtk4.ModifierType_BUTTON1_MASK
         return 1
@@ -147,7 +149,7 @@ function _get_button(modifiers, e::GtkEventController)
     elseif modifiers & Gtk4.ModifierType_BUTTON3_MASK == Gtk4.ModifierType_BUTTON3_MASK
         return 3        
     else
-        return isa(e, GtkGestureSingle) ? Gtk4.current_button(e) : 0
+        return 0
     end
 end
 
@@ -301,7 +303,7 @@ function save_cb(::Ptr,par,c)
             end
         catch e
             if !isa(e, Gtk4.GLib.GErrorException)
-                error_dialog("Failed to save: $e", toplevel(c)) do
+                info_dialog("Failed to save: $e", toplevel(c)) do
                 end
             end
         end

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -141,7 +141,7 @@ function slider(range::AbstractRange;
         Gtk4.draw_value(widget,true)
         Gtk4.size_request(widget, 200, -1)
     else
-        adj = Gtk4.GtkAdjustment(widget)
+        adj = Gtk4.adjustment(widget)
         Gtk4.configure!(adj; lower = first(range), upper = last(range), step_increment = step(range))
     end
     Gtk4.value(widget, value)
@@ -171,7 +171,7 @@ end
 # Is calling this `setindex!` too much of a pun?
 function Base.setindex!(s::Slider, (range,value)::Tuple{AbstractRange, Any})
     first(range) <= value <= last(range) || error("$value is not within the span of $range")
-    adj = Gtk4.GtkAdjustment(widget(s))
+    adj = Gtk4.adjustment(widget(s))
     @idle_add Gtk4.configure!(adj; value = value, lower = first(range), upper = last(range), step_increment = step(range))
 end
 Base.setindex!(s::Slider, range::AbstractRange) = setindex!(s, (range, s[]))
@@ -952,7 +952,7 @@ function spinbutton(range::AbstractRange{T};
                           first(range), last(range), step(range))
         Gtk4.size_request(widget, 200, -1)
     else
-        adj = Gtk4.GtkAdjustment(widget)
+        adj = Gtk4.adjustment(widget)
         Gtk4.configure!(adj; lower=first(range), upper=last(range), step_increment=step(range))
     end
     if lowercase(first(orientation)) == 'v'
@@ -982,7 +982,7 @@ end
 # Is calling this `setindex!` too much of a pun?
 function Base.setindex!(s::SpinButton, (range,value)::Tuple{AbstractRange,Any})
     first(range) <= value <= last(range) || error("$value is not within the span of $range")
-    adj = Gtk4.GtkAdjustment(widget(s))
+    adj = Gtk4.adjustment(widget(s))
     Gtk4.configure!(adj; value = value, lower = first(range), upper = last(range), step_increment = step(range))
 end
 Base.setindex!(s::SpinButton, range::AbstractRange) = setindex!(s, (range, s[]))
@@ -1036,7 +1036,7 @@ function cyclicspinbutton(range::AbstractRange{T}, carry_up::Observable{Bool};
         widget = GtkSpinButton(first(range) - step(range), last(range) + step(range), step(range))
         Gtk4.size_request(widget, 200, -1)
     else
-        adj = Gtk4.GtkAdjustment(widget)
+        adj = Gtk4.adjustment(widget)
         Gtk4.configure!(adj; lower = first(range) - step(range), upper = last(range) + step(range), step_increment = step(range))
     end
     if lowercase(first(orientation)) == 'v'


### PR DESCRIPTION
None of the breaking changes in Gtk4 0.7 affect GtkObservables so there's no need to drop v0.6. Still this PR does switch away from deprecated methods.