### PR TITLE
fix warning on Julia 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        version: ['1', 'nightly']
+        version: ['lts', '1', 'pre']
         arch: [x64, x86]
         include:
           - os: ubuntu-latest
@@ -24,13 +24,13 @@ jobs:
           - os: macOS-latest
             arch: x86
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-runtest@master
+      - uses: julia-actions/julia-runtest@latest
         with:
           prefix: ${{ matrix.prefix }}
       - uses: julia-actions/julia-processcoverage@latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GtkObservables"
 uuid = "8710efd8-4ad6-11eb-33ea-2d5ceb25a41c"
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"

--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -16,7 +16,7 @@ Base.convert(::Type{T}, x::T) where {T<:CairoUnit} = x
 (::Type{T})(x::CairoUnit) where T<:Real = T(x.val)
 
 # Ambiguity resolution
-Bool(x::CairoUnit) = Bool(x.val)
+Base.Bool(x::CairoUnit) = Bool(x.val)
 
 # The next three are for ambiguity resolution
 Base.promote_rule(::Type{Bool}, ::Type{U}) where {U<:CairoUnit} = Float64


### PR DESCRIPTION
Qualify `Bool` to silence a warning on Julia 1.12 rc1. Fixes #76

CI appeared to hang on "nightly" so I cancelled it and changed CI setup here to follow ProfileView's, which tests on "lts", "1", and "pre".