### PR TITLE
prevent adding a method to the functions `>`

### DIFF
--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -5,7 +5,6 @@ abstract type CairoUnit <: Real end
 Base.:+(x::U, y::U) where {U<:CairoUnit} = U(x.val + y.val)
 Base.:-(x::U, y::U) where {U<:CairoUnit} = U(x.val - y.val)
 Base.:<(x::U, y::U) where {U<:CairoUnit} = Bool(x.val < y.val)
-Base.:>(x::U, y::U) where {U<:CairoUnit} = Bool(x.val > y.val)
 Base.abs(x::U) where {U<:CairoUnit} = U(abs(x.val))
 Base.min(x::U, y::U) where {U<:CairoUnit} = U(min(x.val, y.val))
 Base.max(x::U, y::U) where {U<:CairoUnit} = U(max(x.val, y.val))


### PR DESCRIPTION
As documented, the intended way to implement `>` is to add a method to `<`. A package should never add a method to `>`.